### PR TITLE
test: add mainnetv2 stataWrapper

### DIFF
--- a/test/mainnet/ERC4626MainnetAaveUsdcV2.t.sol
+++ b/test/mainnet/ERC4626MainnetAaveUsdcV2.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetAaveUsdcV2Test is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+
+        // Aave's aUsdc
+        wrapper = IERC4626(0xD4fa2D31b7968E448877f69A96DE69f5de8cD23E);
+        // Donor of USDC tokens
+        underlyingDonor = 0x4B16c5dE96EB2117bBE5fd171E4d203624B014aa;
+        amountToDonate = 1e6 * 1e6;
+    }
+}


### PR DESCRIPTION
# Description

<!-- Describe the tokens added in this PR, with addresses and chains. -->

There are StatAV2 wrappers for aave tokens being used as erc4626 Tokens. This pr adds one deployed on mainnet. 
0xD4fa2D31b7968E448877f69A96DE69f5de8cD23E