### PR TITLE
New statA tokens

### DIFF
--- a/test/gnosis/ERC4626GnosisAaveWeth.t.sol
+++ b/test/gnosis/ERC4626GnosisAaveWeth.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626GnosisAaveWethTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "gnosis";
+
+        // Aave's Weth
+        wrapper = IERC4626(0x57f664882F762FA37903FC864e2B633D384B411A);
+        // Donor of Weth
+        underlyingDonor = 0xBA12222222228d8Ba445958a75a0704d566BF2C8;
+        amountToDonate = 500 * 1e18;
+    }
+}

--- a/test/mainnet/ERC4626MainnetAaveLidoWeth.t.sol
+++ b/test/mainnet/ERC4626MainnetAaveLidoWeth.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetAaveLidoWethTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+
+        // Aave's Lido WETH
+        wrapper = IERC4626(0x0FE906e030a44eF24CA8c7dC7B7c53A6C4F00ce9);
+        // Donor of WETH tokens
+        underlyingDonor = 0xF04a5cC80B1E94C69B48f5ee68a08CD2F09A7c3E;
+        amountToDonate = 1e5 * 1e18;
+    }
+}

--- a/test/mainnet/ERC4626MainnetAaveLidoWstEth.t.sol
+++ b/test/mainnet/ERC4626MainnetAaveLidoWstEth.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetAaveLidoWstEthTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+
+        // Aave's Lido WstETH
+        wrapper = IERC4626(0x775F661b0bD1739349b9A2A3EF60be277c5d2D29);
+        // Donor of WstETH tokens
+        underlyingDonor = 0x12B54025C112Aa61fAce2CDB7118740875A566E9;
+        amountToDonate = 1e5 * 1e18;
+    }
+}

--- a/test/mainnet/ERC4626MainnetAaveUsdt2.t.sol
+++ b/test/mainnet/ERC4626MainnetAaveUsdt2.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetAaveUsdt2Test is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+
+        // Aave's USDT
+        wrapper = IERC4626(0x7Bc3485026Ac48b6cf9BaF0A377477Fff5703Af8);
+        // Donor of USDT
+        underlyingDonor = 0xF977814e90dA44bFA03b6295A0616a897441aceC;
+        amountToDonate = 1e6 * 1e6;
+    }
+}

--- a/test/mainnet/ERC4626MainnetAaveWeth.t.sol
+++ b/test/mainnet/ERC4626MainnetAaveWeth.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetAaveWethTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+
+        // Aave's WETH
+        wrapper = IERC4626(0x0bfc9d54Fc184518A81162F8fB99c2eACa081202);
+        // Donor of WETH tokens
+        underlyingDonor = 0xF04a5cC80B1E94C69B48f5ee68a08CD2F09A7c3E;
+        amountToDonate = 1e5 * 1e18;
+    }
+}


### PR DESCRIPTION
# Description

Added the following tokens to the tests:

* Gnosis:
   * Wrapped Aave Gnosis WETH - [0x57f664882F762FA37903FC864e2B633D384B411A](https://gnosisscan.io/address/0x57f664882F762FA37903FC864e2B633D384B411A)
* Mainnet:
   * Wrapped Aave Ethereum Lido WETH - [0x0FE906e030a44eF24CA8c7dC7B7c53A6C4F00ce9](https://etherscan.io/address/0x0FE906e030a44eF24CA8c7dC7B7c53A6C4F00ce9)
   * Wrapped Aave Ethereum Lido WstETH - [0x775F661b0bD1739349b9A2A3EF60be277c5d2D29](https://etherscan.io/address/0x775F661b0bD1739349b9A2A3EF60be277c5d2D29)
   * Wrapped Aave Ethereum USDT - [0x7Bc3485026Ac48b6cf9BaF0A377477Fff5703Af8](https://etherscan.io/address/0x7Bc3485026Ac48b6cf9BaF0A377477Fff5703Af8)
   * Wrapped Aave Ethereum WETH - [0x0bfc9d54Fc184518A81162F8fB99c2eACa081202](https://etherscan.io/address/0x0bfc9d54Fc184518A81162F8fB99c2eACa081202)
