### PR TITLE
Morpho 1.1 tests

### DIFF
--- a/test/ERC4626WrapperBase.t.sol
+++ b/test/ERC4626WrapperBase.t.sol
@@ -411,7 +411,7 @@ abstract contract ERC4626WrapperBaseTest is Test {
         // Block Numbers are based on the deployment of BufferRouter.
 
         if (_compareStrings(network, "mainnet")) {
-            blockNumber = 21339384;
+            blockNumber = 21573249;
             permit2 = IPermit2(0x000000000022D473030F116dDEE9F6B43aC78BA3);
             bufferRouter = IBufferRouter(0x9179C06629ef7f17Cb5759F501D89997FE0E7b45);
             vault = IVaultForERC4626Test(0xbA1333333333a1BA1108E8412f11850A5C319bA9);

--- a/test/ERC4626WrapperBase.t.sol
+++ b/test/ERC4626WrapperBase.t.sol
@@ -22,11 +22,14 @@ abstract contract ERC4626WrapperBaseTest is Test {
 
     // Variables to be defined by setUpForkTestVariables().
     string internal network;
-    uint256 internal blockNumber;
+    // Use overrideBlockNumber to specify a block number in a specific test.
     uint256 internal overrideBlockNumber;
     IERC4626 internal wrapper;
     address internal underlyingDonor;
     uint256 internal amountToDonate;
+
+    // blockNumber is used by the base test. To override it, please use overrideBlockNumber.
+    uint256 internal blockNumber;
 
     IBufferRouter internal bufferRouter;
     IVaultForERC4626Test internal vault;
@@ -410,7 +413,8 @@ abstract contract ERC4626WrapperBaseTest is Test {
 
     function _configurePermit2AndBufferToNetwork() private {
         // Block Numbers are based on the deployment of BufferRouter.
-        // If a test requires a new blockNumber, change it in the test itself. Do not change the values below.
+        // IMPORTANT: If a test requires a new blockNumber, change `overrideBlockNumber` in the test itself using the
+        // function `setUpForkTestVariables()`. Do not change the values below, since all tests depend on it.
 
         if (_compareStrings(network, "mainnet")) {
             blockNumber = overrideBlockNumber != 0 ? overrideBlockNumber : 21339384;

--- a/test/ERC4626WrapperBase.t.sol
+++ b/test/ERC4626WrapperBase.t.sol
@@ -23,6 +23,7 @@ abstract contract ERC4626WrapperBaseTest is Test {
     // Variables to be defined by setUpForkTestVariables().
     string internal network;
     uint256 internal blockNumber;
+    uint256 internal overrideBlockNumber;
     IERC4626 internal wrapper;
     address internal underlyingDonor;
     uint256 internal amountToDonate;
@@ -409,19 +410,20 @@ abstract contract ERC4626WrapperBaseTest is Test {
 
     function _configurePermit2AndBufferToNetwork() private {
         // Block Numbers are based on the deployment of BufferRouter.
+        // If a test requires a new blockNumber, change it in the test itself. Do not change the values below.
 
         if (_compareStrings(network, "mainnet")) {
-            blockNumber = 21573249;
+            blockNumber = overrideBlockNumber != 0 ? overrideBlockNumber : 21339384;
             permit2 = IPermit2(0x000000000022D473030F116dDEE9F6B43aC78BA3);
             bufferRouter = IBufferRouter(0x9179C06629ef7f17Cb5759F501D89997FE0E7b45);
             vault = IVaultForERC4626Test(0xbA1333333333a1BA1108E8412f11850A5C319bA9);
         } else if (_compareStrings(network, "gnosis")) {
-            blockNumber = 37377481;
+            blockNumber = overrideBlockNumber != 0 ? overrideBlockNumber : 37377481;
             permit2 = IPermit2(0x000000000022D473030F116dDEE9F6B43aC78BA3);
             bufferRouter = IBufferRouter(0x86e67E115f96DF37239E0479441303De0de7bc2b);
             vault = IVaultForERC4626Test(0xbA1333333333a1BA1108E8412f11850A5C319bA9);
         } else if (_compareStrings(network, "sepolia")) {
-            blockNumber = 7219291;
+            blockNumber = overrideBlockNumber != 0 ? overrideBlockNumber : 7219291;
             permit2 = IPermit2(0x000000000022D473030F116dDEE9F6B43aC78BA3);
             bufferRouter = IBufferRouter(0xb5F3A41515457CC6E2716c62a011D260441CcfC9);
             vault = IVaultForERC4626Test(0xbA1333333333a1BA1108E8412f11850A5C319bA9);

--- a/test/ERC4626WrapperBase.t.sol
+++ b/test/ERC4626WrapperBase.t.sol
@@ -81,8 +81,9 @@ abstract contract ERC4626WrapperBaseTest is Test {
     }
 
     /**
-     * @notice Defines network, blockNumber, wrapper, underlyingDonor and amountToDonate.
-     * @dev Make sure the underlyingDonor has at least amountToDonate underlying tokens.
+     * @notice Defines network, overrideBlockNumber, wrapper, underlyingDonor and amountToDonate.
+     * @dev Make sure the underlyingDonor has at least amountToDonate underlying tokens, and that the buffer was not
+     * initialized for the ERC4626 token in the current block number.
      */
     function setUpForkTestVariables() internal virtual;
 

--- a/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDC.t.sol
+++ b/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDC.t.sol
@@ -15,12 +15,12 @@ contract ERC4626MainnetMorphoSteakhouseUsdcTest is ERC4626WrapperBaseTest {
 
     function setUpForkTestVariables() internal override {
         network = "mainnet";
-        overrideBlockNumber = 21573249;
+        overrideBlockNumber = 21537026;
 
         // Morpho's Steakhouse USDC
         wrapper = IERC4626(0x7204B7Dbf9412567835633B6F00C3Edc3a8D6330);
         // Donor of USDC tokens
-        underlyingDonor = 0xbA1333333333a1BA1108E8412f11850A5C319bA9;
+        underlyingDonor = 0x37305B1cD40574E4C5Ce33f8e8306Be057fD7341;
         amountToDonate = 10_000 * 1e6;
     }
 }

--- a/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDC.t.sol
+++ b/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDC.t.sol
@@ -17,9 +17,9 @@ contract ERC4626MainnetMorphoSteakhouseUsdcTest is ERC4626WrapperBaseTest {
         network = "mainnet";
 
         // Morpho's Steakhouse USDC
-        wrapper = IERC4626(0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB);
+        wrapper = IERC4626(0x7204B7Dbf9412567835633B6F00C3Edc3a8D6330);
         // Donor of USDC tokens
-        underlyingDonor = 0x4B16c5dE96EB2117bBE5fd171E4d203624B014aa;
-        amountToDonate = 1e6 * 1e6;
+        underlyingDonor = 0xbA1333333333a1BA1108E8412f11850A5C319bA9;
+        amountToDonate = 10_000 * 1e6;
     }
 }

--- a/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDC.t.sol
+++ b/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDC.t.sol
@@ -15,6 +15,7 @@ contract ERC4626MainnetMorphoSteakhouseUsdcTest is ERC4626WrapperBaseTest {
 
     function setUpForkTestVariables() internal override {
         network = "mainnet";
+        overrideBlockNumber = 21573249;
 
         // Morpho's Steakhouse USDC
         wrapper = IERC4626(0x7204B7Dbf9412567835633B6F00C3Edc3a8D6330);

--- a/test/mainnet/ERC4626MainnetMorphoSteakhouseWUSDL.t.sol
+++ b/test/mainnet/ERC4626MainnetMorphoSteakhouseWUSDL.t.sol
@@ -15,12 +15,12 @@ contract ERC4626MainnetMorphoSteakhouseWUSDLTest is ERC4626WrapperBaseTest {
 
     function setUpForkTestVariables() internal override {
         network = "mainnet";
-        overrideBlockNumber = 21573249;
+        overrideBlockNumber = 21537026;
 
         // Morpho's Steakhouse wUSDL
         wrapper = IERC4626(0xbEeFc011e94f43b8B7b455eBaB290C7Ab4E216f1);
         // Donor of wUSDL tokens
-        underlyingDonor = 0xbA1333333333a1BA1108E8412f11850A5C319bA9;
+        underlyingDonor = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb;
         amountToDonate = 10_000 * 1e18;
     }
 }

--- a/test/mainnet/ERC4626MainnetMorphoSteakhouseWUSDL.t.sol
+++ b/test/mainnet/ERC4626MainnetMorphoSteakhouseWUSDL.t.sol
@@ -17,9 +17,9 @@ contract ERC4626MainnetMorphoSteakhouseWUSDLTest is ERC4626WrapperBaseTest {
         network = "mainnet";
 
         // Morpho's Steakhouse wUSDL
-        wrapper = IERC4626(0xbEEFC01767ed5086f35deCb6C00e6C12bc7476C1);
+        wrapper = IERC4626(0xbEeFc011e94f43b8B7b455eBaB290C7Ab4E216f1);
         // Donor of wUSDL tokens
-        underlyingDonor = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb;
-        amountToDonate = 1e6 * 1e18;
+        underlyingDonor = 0xbA1333333333a1BA1108E8412f11850A5C319bA9;
+        amountToDonate = 10_000 * 1e18;
     }
 }

--- a/test/mainnet/ERC4626MainnetMorphoSteakhouseWUSDL.t.sol
+++ b/test/mainnet/ERC4626MainnetMorphoSteakhouseWUSDL.t.sol
@@ -15,6 +15,7 @@ contract ERC4626MainnetMorphoSteakhouseWUSDLTest is ERC4626WrapperBaseTest {
 
     function setUpForkTestVariables() internal override {
         network = "mainnet";
+        overrideBlockNumber = 21573249;
 
         // Morpho's Steakhouse wUSDL
         wrapper = IERC4626(0xbEeFc011e94f43b8B7b455eBaB290C7Ab4E216f1);


### PR DESCRIPTION
# Description

<!-- Describe the tokens added in this PR, with addresses and chains. -->

Morpho Vaults are replaced by the version 1.1 tokens. Basically they are new vault contracts. 

More context can be found in this pr: https://github.com/balancer/code-review/pull/208