### PR TITLE
test: add GHO & USDe

### DIFF
--- a/test/mainnet/ERC4626MainnetAaveLidoGho.t.sol
+++ b/test/mainnet/ERC4626MainnetAaveLidoGho.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetAaveLidoGhoTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+        overrideBlockNumber = 21587513;
+
+        // Lido Aave's GHO
+        wrapper = IERC4626(0xC71Ea051a5F82c67ADcF634c36FFE6334793D24C);
+        // Donor of GHO tokens
+        underlyingDonor = 0x1a88Df1cFe15Af22B3c4c783D4e6F7F9e0C1885d;
+        amountToDonate = 1e6 * 1e18;
+    }
+}

--- a/test/mainnet/ERC4626MainnetAaveUSDe.t.sol
+++ b/test/mainnet/ERC4626MainnetAaveUSDe.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetAaveUsdeTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+        //overrideBlockNumber = 21537026;
+
+        // Aave's USDe
+        wrapper = IERC4626(0x5F9D59db355b4A60501544637b00e94082cA575b);
+        // Donor of USDe tokens
+        underlyingDonor = 0xA7A93fd0a276fc1C0197a5B5623eD117786eeD06;
+        amountToDonate = 1e6 * 1e18;
+    }
+}

--- a/test/mainnet/ERC4626MainnetAaveUSDe.t.sol
+++ b/test/mainnet/ERC4626MainnetAaveUSDe.t.sol
@@ -15,12 +15,12 @@ contract ERC4626MainnetAaveUsdeTest is ERC4626WrapperBaseTest {
 
     function setUpForkTestVariables() internal override {
         network = "mainnet";
-        //overrideBlockNumber = 21537026;
+        overrideBlockNumber = 21466061;
 
         // Aave's USDe
         wrapper = IERC4626(0x5F9D59db355b4A60501544637b00e94082cA575b);
         // Donor of USDe tokens
-        underlyingDonor = 0xA7A93fd0a276fc1C0197a5B5623eD117786eeD06;
+        underlyingDonor = 0x4dB99b79361F98865230f5702de024C69f629fEC;
         amountToDonate = 1e6 * 1e18;
     }
 }


### PR DESCRIPTION
# Description

<!-- Describe the tokens added in this PR, with addresses and chains. -->

This pr adds:
Wrapped Aave Ethereum USDe - 0x5F9D59db355b4A60501544637b00e94082cA575b
and
Wrapped Aave Lido Ethereum GHO - 0xC71Ea051a5F82c67ADcF634c36FFE6334793D24C

Relevant code-review pr: https://github.com/balancer/code-review/pull/207/files 