### PR TITLE
Add Silo V2 solvBtc test

### DIFF
--- a/test/sonic/ERC4626SonicSiloSolvBtc.t.sol
+++ b/test/sonic/ERC4626SonicSiloSolvBtc.t.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626SonicSiloV2SolvBTCTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+
+        // By default Silo V2 uses 21 decimals for their ERC4626 implementation.
+        // Specifically to support balancer boosted pools, they've deployed markets with 18 decimals that truncate
+        // the last 3 decimal places. Since the additional 3 digits of precision are always 0 and only used as an
+        // additional layer of security against first deposit attacks, it does not impact the functioning of the market.
+        // As such, the conversion rate is 1:1000, which we account for here by overwriting underlyingToWrappedFactor
+        underlyingToWrappedFactor = 1000;
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "sonic";
+        overrideBlockNumber = 5022201;
+
+        // Silo V2's solvBTC
+        wrapper = IERC4626(0x87178fe8698C7eDa8aA207083C3d66aEa569aB98);
+        // Donor of solvBTC
+        underlyingDonor = 0x6c56DDcCB3726fAa089A5e9E29b712525Cf916D7;
+        amountToDonate = 50 * 1e18;
+    }
+}


### PR DESCRIPTION
# Description

Add back the Silo V2 test that was failing in https://github.com/balancer/balancer-v3-erc4626-tests/pull/12.

By default Silo V2 uses 21 decimals for their ERC4626 implementation. Specifically to support balancer boosted pools, they've deployed markets with 18 decimals that truncate the last 3 decimal places. Since the additional 3 digits of precision are always 0 and only used as an additional layer of security against first deposit attacks, it does not impact the functioning of the market. As such, the conversion rate is 1:1000, which we account for here by overwriting underlyingToWrappedFactor.
