### PR TITLE
Tests for morpho steakhouse USDQ USDR and USDTL

### DIFF
--- a/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDQ.t.sol
+++ b/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDQ.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetMorphoSteakhouseUsdqTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+        overrideBlockNumber = 21735567;
+
+        // Morpho's Steakhouse USDQ
+        wrapper = IERC4626(0xA1b60d96e5C50dA627095B9381dc5a46AF1a9a42);
+        // Donor of USDQ tokens
+        underlyingDonor = 0xCED0E43EEebF37e49Faaf064640b1FB228d18a12;
+        amountToDonate = 1e6 * 1e6;
+    }
+}

--- a/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDR.t.sol
+++ b/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDR.t.sol
@@ -21,6 +21,6 @@ contract ERC4626MainnetMorphoSteakhouseUsdrTest is ERC4626WrapperBaseTest {
         wrapper = IERC4626(0x30881Baa943777f92DC934d53D3bFdF33382cab3);
         // Donor of USDR tokens
         underlyingDonor = 0x77134cbC06cB00b66F4c7e623D5fdBF6777635EC; // Bitfinex Hot Wallet
-        amountToDonate = 1e6 * 1e6;
+        amountToDonate = 1e4 * 1e6;
     }
 }

--- a/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDR.t.sol
+++ b/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDR.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetMorphoSteakhouseUsdrTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+        overrideBlockNumber = 21735567;
+
+        // Morpho's Steakhouse USDR
+        wrapper = IERC4626(0x30881Baa943777f92DC934d53D3bFdF33382cab3);
+        // Donor of USDR tokens
+        underlyingDonor = 0x77134cbC06cB00b66F4c7e623D5fdBF6777635EC; // Bitfinex Hot Wallet
+        amountToDonate = 1e6 * 1e6;
+    }
+}

--- a/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDTL.t.sol
+++ b/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDTL.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetMorphoSteakhouseUsdtLiteTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+        overrideBlockNumber = 21735567;
+
+        // Morpho's Steakhouse USDT lite
+        wrapper = IERC4626(0x097FFEDb80d4b2Ca6105a07a4D90eB739C45A666);
+        // Donor of USDT tokens
+        underlyingDonor = 0xF977814e90dA44bFA03b6295A0616a897441aceC;
+        amountToDonate = 1e6 * 1e6;
+    }
+}


### PR DESCRIPTION
Related to https://github.com/balancer/code-review/pull/247

### Notes
USDR and USDQ are recently deployed tokens

### Debug
USDR test was failing because top holder doesn't have enough liquidity, so I lowered to `amountToDonate` to `1e4 * 1e6`

Ran token balances for all wallets that have received USDR https://etherscan.io/address/0x7B43E3875440B44613DC3bC08E7763e6Da63C8f8

Top Holder: `0x77134cbC06cB00b66F4c7e623D5fdBF6777635EC`
Balance: `49990000000`

