### PR TITLE
Add tests for superform USDC on base and mainnet

### DIFF
--- a/test/base/ERC4626BaseSuperFormUSDC.t.sol
+++ b/test/base/ERC4626BaseSuperFormUSDC.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626BaseSuperformUsdcTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "base";
+        overrideBlockNumber = 25787269;
+
+        // Superform USDC
+        wrapper = IERC4626(0xe9F2a5F9f3c846f29066d7fB3564F8E6B6b2D65b);
+        // Donor of USDC tokens
+        underlyingDonor = 0xee81B5Afc73Cf528778E0ED98622e434E5eFADb4;
+        amountToDonate = 1e6 * 1e6;
+    }
+}

--- a/test/mainnet/ERC4626MainnetSuperFormUSDC.t.sol
+++ b/test/mainnet/ERC4626MainnetSuperFormUSDC.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetSuperformUsdcTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+        overrideBlockNumber = 21747569;
+
+        // Superform USDC
+        wrapper = IERC4626(0xF7DE3c70F2db39a188A81052d2f3C8e3e217822a);
+        // Donor of USDC tokens
+        underlyingDonor = 0x37305B1cD40574E4C5Ce33f8e8306Be057fD7341;
+        amountToDonate = 1e6 * 1e6;
+    }
+}


### PR DESCRIPTION
Related to https://github.com/balancer/code-review/pull/257

### Summary
- Superform SuperVaults are failing the `testWithdraw` because of `revert: too much loss;`

```
Ran 1 test for test/mainnet/ERC4626MainnetSuperFormUSDC.t.sol:ERC4626MainnetSuperformUsdcTest
[FAIL: revert: too much loss; counterexample: calldata=0x20c1d8510000000000000000000000000000000000009be307e764714a2fb8581d484ac5 args=[3161760727588006476801643857332933 [3.161e33]]] testWithdraw__Fork__Fuzz(uint256) (runs: 0, μ: 0, ~: 0)
Logs:
  Bound Result 433650401339

Suite result: FAILED. 0 passed; 1 failed; 0 skipped; finished in 284.02ms (20.53ms CPU time)

Ran 1 test suite in 287.79ms (284.02ms CPU time): 0 tests passed, 1 failed, 0 skipped (1 total tests)

Failing tests:
Encountered 1 failing test in test/mainnet/ERC4626MainnetSuperFormUSDC.t.sol:ERC4626MainnetSuperformUsdcTest
[FAIL: revert: too much loss; counterexample: calldata=0x20c1d8510000000000000000000000000000000000009be307e764714a2fb8581d484ac5 args=[3161760727588006476801643857332933 [3.161e33]]] testWithdraw__Fork__Fuzz(uint256) (runs: 0, μ: 0, ~: 0)
```