### PR TITLE
Test Fluid tokens on Mainnet

### DIFF
--- a/test/ERC4626WrapperBase.t.sol
+++ b/test/ERC4626WrapperBase.t.sol
@@ -45,7 +45,7 @@ abstract contract ERC4626WrapperBaseTest is Test {
     uint256 internal userInitialShares;
 
     uint256 internal minDeposit = 100;
-    // Tolerance of 1 wei difference between convert/preview and actual operation.
+    // Tolerance between convert/preview and the actual operation.
     uint256 internal constant TOLERANCE = 2;
 
     function setUp() public virtual {

--- a/test/ERC4626WrapperBase.t.sol
+++ b/test/ERC4626WrapperBase.t.sol
@@ -44,7 +44,7 @@ abstract contract ERC4626WrapperBaseTest is Test {
     uint256 internal userInitialUnderlying;
     uint256 internal userInitialShares;
 
-    uint256 internal constant MIN_DEPOSIT = 100;
+    uint256 internal minDeposit = 100;
     // Tolerance of 1 wei difference between convert/preview and actual operation.
     uint256 internal constant TOLERANCE = 2;
 
@@ -107,7 +107,7 @@ abstract contract ERC4626WrapperBaseTest is Test {
     }
 
     function testDeposit__Fork__Fuzz(uint256 amountToDeposit) public {
-        amountToDeposit = bound(amountToDeposit, MIN_DEPOSIT, userInitialUnderlying);
+        amountToDeposit = bound(amountToDeposit, minDeposit, userInitialUnderlying);
 
         uint256 convertedShares = wrapper.convertToShares(amountToDeposit);
         uint256 previewedShares = wrapper.previewDeposit(amountToDeposit);
@@ -146,7 +146,7 @@ abstract contract ERC4626WrapperBaseTest is Test {
         // shares) less a tolerance.
         amountToMint = bound(
             amountToMint,
-            MIN_DEPOSIT * underlyingToWrappedFactor,
+            minDeposit * underlyingToWrappedFactor,
             userInitialShares - (TOLERANCE * underlyingToWrappedFactor)
         );
 
@@ -183,7 +183,7 @@ abstract contract ERC4626WrapperBaseTest is Test {
     function testWithdraw__Fork__Fuzz(uint256 amountToWithdraw) public {
         // When user deposited to underlying, a round down may occur and remove some wei. So, makes sure
         // amountToWithdraw does not pass the amount deposited - a wei tolerance.
-        amountToWithdraw = bound(amountToWithdraw, MIN_DEPOSIT, userInitialUnderlying - TOLERANCE);
+        amountToWithdraw = bound(amountToWithdraw, minDeposit, userInitialUnderlying - TOLERANCE);
 
         uint256 convertedShares = wrapper.convertToShares(amountToWithdraw);
         uint256 previewedShares = wrapper.previewWithdraw(amountToWithdraw);
@@ -216,7 +216,7 @@ abstract contract ERC4626WrapperBaseTest is Test {
     function testRedeem__Fork__Fuzz(uint256 amountToRedeem) public {
         // When user deposited to underlying, a round down may occur and remove some wei. So, makes sure
         // amountToWithdraw does not pass the amount deposited - a wei tolerance.
-        amountToRedeem = bound(amountToRedeem, MIN_DEPOSIT * underlyingToWrappedFactor, userInitialShares - TOLERANCE);
+        amountToRedeem = bound(amountToRedeem, minDeposit * underlyingToWrappedFactor, userInitialShares - TOLERANCE);
 
         uint256 convertedAssets = wrapper.convertToAssets(amountToRedeem);
         uint256 previewedAssets = wrapper.previewRedeem(amountToRedeem);

--- a/test/ERC4626WrapperBase.t.sol
+++ b/test/ERC4626WrapperBase.t.sol
@@ -44,6 +44,7 @@ abstract contract ERC4626WrapperBaseTest is Test {
     uint256 internal userInitialUnderlying;
     uint256 internal userInitialShares;
 
+    // Some tokens have specific minimum deposit requirements, and need to override this default value.
     uint256 internal minDeposit = 100;
     // Tolerance between convert/preview and the actual operation.
     uint256 internal constant TOLERANCE = 2;
@@ -164,8 +165,8 @@ abstract contract ERC4626WrapperBaseTest is Test {
         uint256 balanceUnderlyingAfter = underlyingToken.balanceOf(user);
         uint256 balanceSharesAfter = wrapper.balanceOf(user);
 
-        assertEq(balanceUnderlyingAfter, balanceUnderlyingBefore - depositedUnderlying, "Mint is not EXACT_OUT");
-        assertEq(balanceSharesAfter, balanceSharesBefore + amountToMint, "Mint shares do not match");
+        assertEq(balanceUnderlyingAfter, balanceUnderlyingBefore - depositedUnderlying, "Mint assets do not match");
+        assertEq(balanceSharesAfter, balanceSharesBefore + amountToMint, "Mint is not EXACT_OUT");
         assertApproxEqAbs(
             convertedUnderlying,
             depositedUnderlying,

--- a/test/mainnet/ERC4626MainnetFluidGho.t.sol
+++ b/test/mainnet/ERC4626MainnetFluidGho.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetFluidGhoTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+
+        // This token has a minimum amount to deposit and mint, or else it fails.
+        minDeposit = 1e9;
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+
+        // Fluid's GHO
+        wrapper = IERC4626(0x6A29A46E21C730DcA1d8b23d637c101cec605C5B);
+        // Donor of GHO tokens
+        underlyingDonor = 0x1a88Df1cFe15Af22B3c4c783D4e6F7F9e0C1885d;
+        amountToDonate = 1e6 * 1e18;
+    }
+}

--- a/test/mainnet/ERC4626MainnetFluidGho.t.sol
+++ b/test/mainnet/ERC4626MainnetFluidGho.t.sol
@@ -12,7 +12,7 @@ contract ERC4626MainnetFluidGhoTest is ERC4626WrapperBaseTest {
     function setUp() public override {
         ERC4626WrapperBaseTest.setUp();
 
-        // This token has a minimum amount to deposit and mint, or else it fails.
+        // This token has specific minimum deposit and mint requirements, so we need to override the default here.
         minDeposit = 1e9;
     }
 

--- a/test/mainnet/ERC4626MainnetFluidUsdc.t.sol
+++ b/test/mainnet/ERC4626MainnetFluidUsdc.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetFluidUsdcTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+
+        // Fluid's USDC
+        wrapper = IERC4626(0x9Fb7b4477576Fe5B32be4C1843aFB1e55F251B33);
+        // Donor of USDC tokens
+        underlyingDonor = 0x4B16c5dE96EB2117bBE5fd171E4d203624B014aa;
+        amountToDonate = 1e6 * 1e6;
+    }
+}

--- a/test/mainnet/ERC4626MainnetFluidUsdt.t.sol
+++ b/test/mainnet/ERC4626MainnetFluidUsdt.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetFluidUsdtTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+
+        // Fluid's USDT
+        wrapper = IERC4626(0x5C20B550819128074FD538Edf79791733ccEdd18);
+        // Donor of USDT
+        underlyingDonor = 0xF977814e90dA44bFA03b6295A0616a897441aceC;
+        amountToDonate = 1e6 * 1e6;
+    }
+}

--- a/test/mainnet/ERC4626MainnetFluidWeth.t.sol
+++ b/test/mainnet/ERC4626MainnetFluidWeth.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetFluidWethTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+
+        // This token has a minimum amount to deposit and mint, or else it fails.
+        minDeposit = 2e6;
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+
+        // Fluid's WETH
+        wrapper = IERC4626(0x90551c1795392094FE6D29B758EcCD233cFAa260);
+        // Donor of WETH tokens
+        underlyingDonor = 0xF04a5cC80B1E94C69B48f5ee68a08CD2F09A7c3E;
+        // The wrapper has a maximum amount to deposit and withdraw, or else it fails.
+        amountToDonate = 1e3 * 1e18;
+    }
+}

--- a/test/mainnet/ERC4626MainnetFluidWeth.t.sol
+++ b/test/mainnet/ERC4626MainnetFluidWeth.t.sol
@@ -12,7 +12,7 @@ contract ERC4626MainnetFluidWethTest is ERC4626WrapperBaseTest {
     function setUp() public override {
         ERC4626WrapperBaseTest.setUp();
 
-        // This token has a minimum amount to deposit and mint, or else it fails.
+        // This token has specific minimum deposit and mint requirements, so we need to override the default here.
         minDeposit = 2e6;
     }
 

--- a/test/mainnet/ERC4626MainnetFluidWstEth.t.sol
+++ b/test/mainnet/ERC4626MainnetFluidWstEth.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetFluidWstEthTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+
+        // This token has a minimum amount to deposit and mint, or else it fails.
+        minDeposit = 1.1e6;
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+
+        // Fluid's WstETH
+        wrapper = IERC4626(0x2411802D8BEA09be0aF8fD8D08314a63e706b29C);
+        // Donor of WstETH tokens
+        underlyingDonor = 0x12B54025C112Aa61fAce2CDB7118740875A566E9;
+        // The wrapper has a maximum amount to deposit and withdraw, or else it fails.
+        amountToDonate = 1e3 * 1e18;
+    }
+}

--- a/test/mainnet/ERC4626MainnetFluidWstEth.t.sol
+++ b/test/mainnet/ERC4626MainnetFluidWstEth.t.sol
@@ -12,7 +12,7 @@ contract ERC4626MainnetFluidWstEthTest is ERC4626WrapperBaseTest {
     function setUp() public override {
         ERC4626WrapperBaseTest.setUp();
 
-        // This token has a minimum amount to deposit and mint, or else it fails.
+        // This token has specific minimum deposit and mint requirements, so we need to override the default here.
         minDeposit = 1.1e6;
     }
 


### PR DESCRIPTION
# Description

Important: We noticed some minimum and maximum limits on deposits and withdrawals of certain tokens, as described below. It allows the buffers to work, but if these limits are trespassed the transaction may revert.

* fWETH and fWSTETH: Minimum deposit/withdraw of `2e6 wei`,  maximum deposit/mint of 1000 ETH
* fGHO: Minimum deposit/withdraw of `1e9 wei`

<!-- Describe the tokens added in this PR, with addresses and chains. -->
Mainnet:
* fWETH: 0x90551c1795392094FE6D29B758EcCD233cFAa260
* fWSTETH: 0x2411802D8BEA09be0aF8fD8D08314a63e706b29C
* fUSDC: 0x9Fb7b4477576Fe5B32be4C1843aFB1e55F251B33
* fUSDT: 0x5C20B550819128074FD538Edf79791733ccEdd18
* fGHO: 0x6A29A46E21C730DcA1d8b23d637c101cec605C5B

