### PR TITLE
aave on sonic

### DIFF
--- a/test/sonic/ERC4626SonicAaveUsdc.t.sol
+++ b/test/sonic/ERC4626SonicAaveUsdc.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626SonicAaveUsdcTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "sonic";
+        overrideBlockNumber = 12031248;
+
+        // Aave USDCE
+        wrapper = IERC4626(0x6646248971427B80ce531bdD793e2Eb859347E55);
+        // Donor of USDCE
+        underlyingDonor = 0x322e1d5384aa4ED66AeCa770B95686271de61dc3;
+        amountToDonate = 1e6 * 1e6;
+    }
+}

--- a/test/sonic/ERC4626SonicAaveUsdc.t.sol
+++ b/test/sonic/ERC4626SonicAaveUsdc.t.sol
@@ -15,7 +15,7 @@ contract ERC4626SonicAaveUsdcTest is ERC4626WrapperBaseTest {
 
     function setUpForkTestVariables() internal override {
         network = "sonic";
-        overrideBlockNumber = 12031248;
+        overrideBlockNumber = 13405152;
 
         // Aave USDCE
         wrapper = IERC4626(0x6646248971427B80ce531bdD793e2Eb859347E55);

--- a/test/sonic/ERC4626SonicAaveWETH.t.sol
+++ b/test/sonic/ERC4626SonicAaveWETH.t.sol
@@ -20,7 +20,7 @@ contract ERC4626SonicAaveWETHTest is ERC4626WrapperBaseTest {
         // Aave WS
         wrapper = IERC4626(0xeB5e9B0ae5bb60274786C747A1A2A798c11271E0);
         // Donor of WS
-        underlyingDonor = 0x3bcE5CB273F0F148010BbEa2470e7b5df84C7812;
+        underlyingDonor = 0xe18Ab82c81E7Eecff32B8A82B1b7d2d23F1EcE96;
         amountToDonate = 1e3 * 1e18;
     }
 }

--- a/test/sonic/ERC4626SonicAaveWETH.t.sol
+++ b/test/sonic/ERC4626SonicAaveWETH.t.sol
@@ -15,7 +15,7 @@ contract ERC4626SonicAaveWETHTest is ERC4626WrapperBaseTest {
 
     function setUpForkTestVariables() internal override {
         network = "sonic";
-        overrideBlockNumber = 12031248;
+        overrideBlockNumber = 13405152;
 
         // Aave WS
         wrapper = IERC4626(0xeB5e9B0ae5bb60274786C747A1A2A798c11271E0);

--- a/test/sonic/ERC4626SonicAaveWETH.t.sol
+++ b/test/sonic/ERC4626SonicAaveWETH.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626SonicAaveWETHTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "sonic";
+        overrideBlockNumber = 12031248;
+
+        // Aave WS
+        wrapper = IERC4626(0xeB5e9B0ae5bb60274786C747A1A2A798c11271E0);
+        // Donor of WS
+        underlyingDonor = 0x3bcE5CB273F0F148010BbEa2470e7b5df84C7812;
+        amountToDonate = 1e3 * 1e18;
+    }
+}

--- a/test/sonic/ERC4626SonicAaveWs.t.sol
+++ b/test/sonic/ERC4626SonicAaveWs.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626SonicAaveWsTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "sonic";
+        overrideBlockNumber = 12031248;
+
+        // Aave WS
+        wrapper = IERC4626(0x18B7B8695165290f2767BC63c36D3dFEa4C0F9bB);
+        // Donor of WS
+        underlyingDonor = 0xE223C8e92AA91e966CA31d5C6590fF7167E25801;
+        amountToDonate = 1e6 * 1e18;
+    }
+}

--- a/test/sonic/ERC4626SonicAaveWs.t.sol
+++ b/test/sonic/ERC4626SonicAaveWs.t.sol
@@ -15,7 +15,7 @@ contract ERC4626SonicAaveWsTest is ERC4626WrapperBaseTest {
 
     function setUpForkTestVariables() internal override {
         network = "sonic";
-        overrideBlockNumber = 12031248;
+        overrideBlockNumber = 13405152;
 
         // Aave WS
         wrapper = IERC4626(0x18B7B8695165290f2767BC63c36D3dFEa4C0F9bB);


### PR DESCRIPTION
USDC and WS tests fail because aave supply cap is hit

# Description

<!-- Describe the tokens added in this PR, with addresses and chains. -->
