### PR TITLE
silo scbtc

### DIFF
--- a/test/sonic/ERC4626SonicSiloScBTC32.sol
+++ b/test/sonic/ERC4626SonicSiloScBTC32.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626SonicSiloV2ScBTCTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+
+        // By default Silo V2 uses 21 decimals for their ERC4626 implementation.
+        // Specifically to support balancer boosted pools, they've deployed markets with 18 decimals that truncate
+        // the last 3 decimal places. Since the additional 3 digits of precision are always 0 and only used as an
+        // additional layer of security against first deposit attacks, it does not impact the functioning of the market.
+        // As such, the conversion rate is 1:1000, which we account for here by overwriting underlyingToWrappedFactor
+        underlyingToWrappedFactor = 1000;
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "sonic";
+        overrideBlockNumber = 15587732;
+
+        // Silo V2's scBTC (id 32)
+        wrapper = IERC4626(0x0A94e18bdbCcD048198806d7FF28A1B1D2590724);
+        // Donor of scBTC
+        underlyingDonor = 0x0A94e18bdbCcD048198806d7FF28A1B1D2590724;
+        amountToDonate = 10 * 1e8;
+    }
+}

--- a/test/sonic/ERC4626SonicSiloScBTC32.sol
+++ b/test/sonic/ERC4626SonicSiloScBTC32.sol
@@ -27,7 +27,7 @@ contract ERC4626SonicSiloV2ScBTCTest is ERC4626WrapperBaseTest {
         // Silo V2's scBTC (id 32)
         wrapper = IERC4626(0x0A94e18bdbCcD048198806d7FF28A1B1D2590724);
         // Donor of scBTC
-        underlyingDonor = 0x0A94e18bdbCcD048198806d7FF28A1B1D2590724;
-        amountToDonate = 10 * 1e8;
+        underlyingDonor = 0xBA12222222228d8Ba445958a75a0704d566BF2C8;
+        amountToDonate = 5 * 1e8;
     }
 }

--- a/test/sonic/ERC4626SonicSiloScBTC32.sol
+++ b/test/sonic/ERC4626SonicSiloScBTC32.sol
@@ -28,6 +28,6 @@ contract ERC4626SonicSiloV2ScBTCTest is ERC4626WrapperBaseTest {
         wrapper = IERC4626(0x0A94e18bdbCcD048198806d7FF28A1B1D2590724);
         // Donor of scBTC
         underlyingDonor = 0xBA12222222228d8Ba445958a75a0704d566BF2C8;
-        amountToDonate = 5 * 1e8;
+        amountToDonate = 30 * 1e8;
     }
 }


### PR DESCRIPTION
Adding a new Silo boosted pool.

@joaobrunoah somehow the tests fail with 
```
Encountered 1 failing test in test/sonic/ERC4626SonicSiloScBTC32.sol:ERC4626SonicSiloV2ScBTCTest
[FAIL: revert: StdUtils bound(uint256,uint256,uint256): Max is less than min.;
```


can you check this?