### PR TITLE
test: add wstusr tests

### DIFF
--- a/test/mainnet/ERC4626MainnetResolvUSR.t.sol
+++ b/test/mainnet/ERC4626MainnetResolvUSR.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetMResolvWstUSRTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "mainnet";
+        overrideBlockNumber = 22179810;
+
+        // Resolv wstUSR
+        wrapper = IERC4626(0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055);
+        // Donor of USDR tokens
+        underlyingDonor = 0xD2eE2776F34Ef4E7325745b06E6d464b08D4be0E;
+        amountToDonate = 1e5 * 1e18;
+    }
+}


### PR DESCRIPTION
# Description

chain: mainnet:
token: resolv wstusr. Users can stake USR to receive allocation of Resolv collateral pool profits. Value of stUSR is equal to value of USR. Quantity of stUSR accrues over time (rebasing) from staking rewards. StUSR has a wrapper token, wstUSR. It is a non-rebasing version of staked USR, value of which accrues over time from staking rewards. 


