### PR TITLE
Extra-fi

### DIFF
--- a/test/base/ERC4626BaseWrappedExtraFiXBaseUSDC.t.sol
+++ b/test/base/ERC4626BaseWrappedExtraFiXBaseUSDC.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626BaseWrappedExtraFiXBaseUSDCTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "base";
+        overrideBlockNumber = 30905678;
+
+        // Wrapped ExtraFi X Base USDC
+        wrapper = IERC4626(0x589A7339C6d0c8777E7429F57f2f95c069c37288);
+        // Donor of USDC tokens
+        underlyingDonor = 0xee81B5Afc73Cf528778E0ED98622e434E5eFADb4;
+        amountToDonate = 1e6 * 1e6;
+    }
+}

--- a/test/base/ERC4626BaseWrappedExtraFiXBaseUSR.t.sol
+++ b/test/base/ERC4626BaseWrappedExtraFiXBaseUSR.t.sol
@@ -21,6 +21,8 @@ contract ERC4626BaseWrappedExtraFiXBaseUSRTest is ERC4626WrapperBaseTest {
         wrapper = IERC4626(0x98eFe85735F253a0ed0Be8e2915ff39f9e4AfF0F);
         // Donor of USR tokens
         underlyingDonor = 0x4665d514e82B2F9c78Fa2B984e450F33d9efc842;
+        // The `deposit` function fails with an amount greater than 1e4 * 1e18, because of a boundary in the wrapped
+        // token.
         amountToDonate = 1e4 * 1e18;
     }
 }

--- a/test/base/ERC4626BaseWrappedExtraFiXBaseUSR.t.sol
+++ b/test/base/ERC4626BaseWrappedExtraFiXBaseUSR.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626BaseWrappedExtraFiXBaseUSRTest is ERC4626WrapperBaseTest {
+    function setUp() public override {
+        ERC4626WrapperBaseTest.setUp();
+    }
+
+    function setUpForkTestVariables() internal override {
+        network = "base";
+        overrideBlockNumber = 30905678;
+
+        // Wrapped ExtraFi X Base USR
+        wrapper = IERC4626(0x98eFe85735F253a0ed0Be8e2915ff39f9e4AfF0F);
+        // Donor of USR tokens
+        underlyingDonor = 0x4665d514e82B2F9c78Fa2B984e450F33d9efc842;
+        amountToDonate = 1e4 * 1e18;
+    }
+}


### PR DESCRIPTION
The USR test fails with `amountToDonate` being bigger than 1e4*1e18. This happens as part of the `_deposit` worfklow and fails with "ERC4626: deposit more than max". 

Both ERC4626 Tokens are `StaticATokenLM`. 