### PR TITLE
add fork test for waEthUSDG

### DIFF
--- a/test/mainnet/ERC4626MainnetAaveUsdg.t.sol
+++ b/test/mainnet/ERC4626MainnetAaveUsdg.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest, ERC4626SetupState, ForkState } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetAaveUsdgTest is ERC4626WrapperBaseTest {
+    function _setupFork() internal pure override returns (ForkState memory forkState) {
+        // Notice that when executing this function, the fork has not yet been created, so all chain states are empty.
+        forkState.network = "mainnet";
+        forkState.blockNumber = 25143950;
+    }
+
+    function _setUpForkTestVariables() internal pure override returns (ERC4626SetupState memory erc4626State) {
+        // waEthUSDG
+        erc4626State.wrapper = IERC4626(0x2DF6DfbD281F127a3690c87E4572076778a9EDa5);
+        // Donor of USDG tokens
+        erc4626State.underlyingDonor = 0x228c9f02cbB0e6B5Dd191B539770c82918023b09;
+        erc4626State.amountToDonate = 1e6 * 1e6;
+    }
+}


### PR DESCRIPTION
aEthUSDG is available at https://app.aave.com/reserve-overview/?underlyingAsset=0xe343167631d89b6ffc58b88d6b7fb0228795491d&marketName=proto_mainnet_v3
Stata Token (Wrapper) Contract: https://etherscan.io/token/0x2df6dfbd281f127a3690c87e4572076778a9eda5
All tests pass