### PR TITLE
add Clearstar Euler fork tests on HyperEVM (csUSDC, csUSDH, csUSDT0)

### DIFF
--- a/test/hyperevm/ERC4626HyperEvmEulerClearstarUSDC.t.sol
+++ b/test/hyperevm/ERC4626HyperEvmEulerClearstarUSDC.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest, ERC4626SetupState, ForkState } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626HyperEvmEulerClearstarUSDCTest is ERC4626WrapperBaseTest {
+    function _setupFork() internal pure override returns (ForkState memory forkState) {
+        // Notice that when executing this function, the fork has not yet been created, so all chain states are empty.
+        forkState.network = "hyperevm";
+        forkState.blockNumber = 36228000;
+    }
+
+    function _setUpForkTestVariables() internal pure override returns (ERC4626SetupState memory erc4626State) {
+        // csUSDC (Clearstar Earn USDC)
+        erc4626State.wrapper = IERC4626(0xF868A2B30854FE13e26F7AB7a92609cCb6b9c0e1);
+
+        // Donor of USDC
+        erc4626State.underlyingDonor = 0x02631682AA6039b096B7A764Ba0AE555F658fC24;
+        erc4626State.amountToDonate = 1e4 * 1e6;
+    }
+}

--- a/test/hyperevm/ERC4626HyperEvmEulerClearstarUSDH.t.sol
+++ b/test/hyperevm/ERC4626HyperEvmEulerClearstarUSDH.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest, ERC4626SetupState, ForkState } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626HyperEvmEulerClearstarUSDHTest is ERC4626WrapperBaseTest {
+    function _setupFork() internal pure override returns (ForkState memory forkState) {
+        // Notice that when executing this function, the fork has not yet been created, so all chain states are empty.
+        forkState.network = "hyperevm";
+        forkState.blockNumber = 36228000;
+    }
+
+    function _setUpForkTestVariables() internal pure override returns (ERC4626SetupState memory erc4626State) {
+        // csUSDH (Clearstar Earn USDH)
+        erc4626State.wrapper = IERC4626(0xF38eA9DE758a8F6be08B6E65bc0Ff2f3e3aB741b);
+
+        // Donor of USDH
+        erc4626State.underlyingDonor = 0x4c2c0F0bB2631B02aC9299C59690914ee7A200B8;
+        erc4626State.amountToDonate = 1e4 * 1e6;
+    }
+}

--- a/test/hyperevm/ERC4626HyperEvmEulerClearstarUSDT0.t.sol
+++ b/test/hyperevm/ERC4626HyperEvmEulerClearstarUSDT0.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest, ERC4626SetupState, ForkState } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626HyperEvmEulerClearstarUSDT0Test is ERC4626WrapperBaseTest {
+    function _setupFork() internal pure override returns (ForkState memory forkState) {
+        // Notice that when executing this function, the fork has not yet been created, so all chain states are empty.
+        forkState.network = "hyperevm";
+        forkState.blockNumber = 36228000;
+    }
+
+    function _setUpForkTestVariables() internal pure override returns (ERC4626SetupState memory erc4626State) {
+        // csUSDT0 (Clearstar Earn USDT0)
+        erc4626State.wrapper = IERC4626(0x6dd448d5cb73DC96788d5BE605DD3C5c83864a36);
+
+        // Donor of USDT0
+        erc4626State.underlyingDonor = 0xBD151BeF567dAbf712A811402A27839768a13D70;
+        erc4626State.amountToDonate = 1e4 * 1e6;
+    }
+}


### PR DESCRIPTION
Clearstar Earn vaults (Euler) on HyperEVM.

Contracts:
- csUSDC: https://hyperevmscan.io/token/0xf868a2b30854fe13e26f7ab7a92609ccb6b9c0e1
- csUSDH: https://hyperevmscan.io/token/0xf38ea9de758a8f6be08b6e65bc0ff2f3e3ab741b
- csUSDT0: https://hyperevmscan.io/token/0x6dd448d5cb73dc96788d5be605dd3c5c83864a36

All tests pass.