### PR TITLE
add fork test for PRIME

### DIFF
--- a/test/ERC4626WrapperBase.t.sol
+++ b/test/ERC4626WrapperBase.t.sol
@@ -28,6 +28,8 @@ struct ForkState {
  * @param minDeposit Some ERC4626 protocols require a minimum amount of underlying tokens to deposit
  * @param underlyingToWrappedFactor Some ERC4626 protocols use a different amount of decimals between underlying and
  * the wrapper. This factor scales underlying decimals to wrapper decimals
+ * @param skipTime How much time to skip during setup; defaults to 1 day. Tokens that read from an oracle with a
+ * tight staleness window may need a smaller value to keep the feed fresh
  */
 struct ERC4626SetupState {
     IERC4626 wrapper;
@@ -37,6 +39,7 @@ struct ERC4626SetupState {
     uint256 minDeposit;
     uint256 underlyingToWrappedFactor;
     bool skipMaxTests;
+    uint256 skipTime;
 }
 
 /**
@@ -99,7 +102,7 @@ abstract contract ERC4626WrapperBaseTest is Test {
 
         // Some tokens might have weird interest accrual mechanisms that get reset on transfers.
         // Waiting some time might reveal inconsistencies in these tokens.
-        skip(1 days);
+        skip($.skipTime);
     }
 
     function _setupERC4626State() private {
@@ -119,6 +122,7 @@ abstract contract ERC4626WrapperBaseTest is Test {
         $.underlyingToWrappedFactor = $.underlyingToWrappedFactor == 0
             ? 10 ** ($.wrapper.decimals() - IERC20Metadata(address($.underlyingToken)).decimals())
             : $.underlyingToWrappedFactor;
+        $.skipTime = $.skipTime == 0 ? 1 days : $.skipTime;
     }
 
     /**

--- a/test/mainnet/ERC4626MainnetHastraPrime.t.sol
+++ b/test/mainnet/ERC4626MainnetHastraPrime.t.sol
@@ -21,5 +21,9 @@ contract ERC4626MainnetHastraPrimeTest is ERC4626WrapperBaseTest {
         // Donor of wYLDS tokens
         erc4626State.underlyingDonor = 0x82E5871654b7635A5e3e8B9DDae019Dd3732e866;
         erc4626State.amountToDonate = 1e4 * 1e6;
+        // PRIME reads its rate from a Hastra FeedVerifier backed by a Chainlink Data Streams feed with a 1-hour
+        // staleness window. The default 1-day skip pushes the cached report past that window, reverting the rate
+        // path; 30 minutes keeps the feed fresh.
+        erc4626State.skipTime = 30 minutes;
     }
 }

--- a/test/mainnet/ERC4626MainnetHastraPrime.t.sol
+++ b/test/mainnet/ERC4626MainnetHastraPrime.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest, ERC4626SetupState, ForkState } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetHastraPrimeTest is ERC4626WrapperBaseTest {
+    function _setupFork() internal pure override returns (ForkState memory forkState) {
+        // Notice that when executing this function, the fork has not yet been created, so all chain states are empty.
+        forkState.network = "mainnet";
+        forkState.blockNumber = 25238060;
+    }
+
+    function _setUpForkTestVariables() internal pure override returns (ERC4626SetupState memory erc4626State) {
+        // PRIME
+        erc4626State.wrapper = IERC4626(0x19ebb35279A16207Ec4ba82799CC64715065F7F6);
+        // Donor of wYLDS tokens
+        erc4626State.underlyingDonor = 0x82E5871654b7635A5e3e8B9DDae019Dd3732e866;
+        erc4626State.amountToDonate = 1e4 * 1e6;
+    }
+}


### PR DESCRIPTION
PRIME (Hastra) is a staked-wYLDS ERC4626, available at https://hastra.io
Contract: https://etherscan.io/token/0x19ebb35279a16207ec4ba82799cc64715065f7f6

Heads up: this test currently FAILS (4 pass / 13 fail). All failures are the same StalePrice revert from PRIME's rate path. PRIME does not compute its rate from vault balances; it reads a Chainlink Data Streams feed via a Hastra FeedVerifier (proxy 0xdF4ab20fA7752Be52E41e42F1FD667f37964d6a3) whose defaultMaxStaleness is 3600s (1h). The base test's `skip(1 days)` pushes the cached report ~24h past that limit, so convertToShares/convertToAssets revert. Opening to observe the same failures against CI's RPC while we evaluate boosted compatibility.