### PR TITLE
add fork tests for Aave Core wrappers

### DIFF
--- a/test/mainnet/ERC4626MainnetAaveCoreGho.t.sol
+++ b/test/mainnet/ERC4626MainnetAaveCoreGho.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest, ERC4626SetupState, ForkState } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetAaveCoreGhoTest is ERC4626WrapperBaseTest {
+    function _setupFork() internal pure override returns (ForkState memory forkState) {
+        // Notice that when executing this function, the fork has not yet been created, so all chain states are empty.
+        forkState.network = "mainnet";
+        forkState.blockNumber = 25480000;
+    }
+
+    function _setUpForkTestVariables() internal pure override returns (ERC4626SetupState memory erc4626State) {
+        // waCoreGHO
+        erc4626State.wrapper = IERC4626(0x58C14a5E061c9bC6926c5b853445290F296C2F7B);
+        // Donor of GHO tokens
+        erc4626State.underlyingDonor = 0xA563319BF55fDAbC304A5c1450D4fBa0bcA9776E;
+        erc4626State.amountToDonate = 5e4 * 1e18;
+    }
+}

--- a/test/mainnet/ERC4626MainnetAaveCoreUsdc.t.sol
+++ b/test/mainnet/ERC4626MainnetAaveCoreUsdc.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest, ERC4626SetupState, ForkState } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetAaveCoreUsdcTest is ERC4626WrapperBaseTest {
+    function _setupFork() internal pure override returns (ForkState memory forkState) {
+        // Notice that when executing this function, the fork has not yet been created, so all chain states are empty.
+        forkState.network = "mainnet";
+        forkState.blockNumber = 25480000;
+    }
+
+    function _setUpForkTestVariables() internal pure override returns (ERC4626SetupState memory erc4626State) {
+        // waCoreUSDC
+        erc4626State.wrapper = IERC4626(0x531E90a2376902DE8915789Fcc1075e3B0c153E7);
+        // Donor of USDC tokens
+        erc4626State.underlyingDonor = 0x37305B1cD40574E4C5Ce33f8e8306Be057fD7341;
+        erc4626State.amountToDonate = 1e5 * 1e6;
+    }
+}

--- a/test/mainnet/ERC4626MainnetAaveCoreUsdg.t.sol
+++ b/test/mainnet/ERC4626MainnetAaveCoreUsdg.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest, ERC4626SetupState, ForkState } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetAaveCoreUsdgTest is ERC4626WrapperBaseTest {
+    function _setupFork() internal pure override returns (ForkState memory forkState) {
+        // Notice that when executing this function, the fork has not yet been created, so all chain states are empty.
+        forkState.network = "mainnet";
+        forkState.blockNumber = 25480000;
+    }
+
+    function _setUpForkTestVariables() internal pure override returns (ERC4626SetupState memory erc4626State) {
+        // waCoreUSDG
+        erc4626State.wrapper = IERC4626(0xAC2435E3C25e8246870D33ce0a26988A46d5DB68);
+        // Donor of USDG tokens
+        erc4626State.underlyingDonor = 0x228c9f02cbB0e6B5Dd191B539770c82918023b09;
+        erc4626State.amountToDonate = 1e4 * 1e6;
+    }
+}

--- a/test/mainnet/ERC4626MainnetAaveCoreUsdt.t.sol
+++ b/test/mainnet/ERC4626MainnetAaveCoreUsdt.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest, ERC4626SetupState, ForkState } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626MainnetAaveCoreUsdtTest is ERC4626WrapperBaseTest {
+    function _setupFork() internal pure override returns (ForkState memory forkState) {
+        // Notice that when executing this function, the fork has not yet been created, so all chain states are empty.
+        forkState.network = "mainnet";
+        forkState.blockNumber = 25480000;
+    }
+
+    function _setUpForkTestVariables() internal pure override returns (ERC4626SetupState memory erc4626State) {
+        // waCoreUSDT
+        erc4626State.wrapper = IERC4626(0x5eC44a70F309854fe04d495cFE1B5dA63DD1cc73);
+        // Donor of USDT tokens
+        erc4626State.underlyingDonor = 0xF977814e90dA44bFA03b6295A0616a897441aceC;
+        erc4626State.amountToDonate = 1e5 * 1e6;
+    }
+}


### PR DESCRIPTION
Aave V4 Core Hub wrappers (waCoreUSDC, waCoreUSDT, waCoreGHO, waCoreUSDG) are available at https://github.com/aave-dao/aave-address-book/blob/03c6a3dc27686c1526e4f8e4d71f6edf202f8435/src/AaveV4Ethereum.sol#L377

Contracts:
https://etherscan.io/token/0x531e90a2376902de8915789fcc1075e3b0c153e7
https://etherscan.io/token/0x5ec44a70f309854fe04d495cfe1b5da63dd1cc73
https://etherscan.io/token/0x58c14a5e061c9bc6926c5b853445290f296c2f7b
https://etherscan.io/token/0xac2435e3c25e8246870d33ce0a26988a46d5db68

All tests pass