### PR TITLE
add fork test for waCoreEURC on Avalanche

### DIFF
--- a/test/avalanche/ERC4626AvalancheAaveCoreEURC.t.sol
+++ b/test/avalanche/ERC4626AvalancheAaveCoreEURC.t.sol
@@ -20,6 +20,9 @@ contract ERC4626AvalancheAaveCoreEURCTest is ERC4626WrapperBaseTest {
         erc4626State.wrapper = IERC4626(0x7b538a1840EAf2Ed92EEB67eE744AE627335e201);
         // Donor of EURC tokens
         erc4626State.underlyingDonor = 0xBF14DB80D9275FB721383a77C00Ae180fc40ae98;
-        erc4626State.amountToDonate = 1e5 * 1e6;
+        // Each of the 3 wallets is donated `amountToDonate` and deposits half of it, so 60K donated means 30K wrapped
+        // per wallet, i.e. 90K wrapped across the test. The Aave Core EURC market at this block has a 150K supply cap,
+        // so increasing the donation further would exhaust the cap and revert with AddCapExceeded.
+        erc4626State.amountToDonate = 6e4 * 1e6;
     }
 }

--- a/test/avalanche/ERC4626AvalancheAaveCoreEURC.t.sol
+++ b/test/avalanche/ERC4626AvalancheAaveCoreEURC.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ERC4626WrapperBaseTest, ERC4626SetupState, ForkState } from "../ERC4626WrapperBase.t.sol";
+
+contract ERC4626AvalancheAaveCoreEURCTest is ERC4626WrapperBaseTest {
+    function _setupFork() internal pure override returns (ForkState memory forkState) {
+        // Notice that when executing this function, the fork has not yet been created, so all chain states are empty.
+        forkState.network = "avalanche";
+        forkState.blockNumber = 90408149;
+    }
+
+    function _setUpForkTestVariables() internal pure override returns (ERC4626SetupState memory erc4626State) {
+        // waCoreEURC
+        erc4626State.wrapper = IERC4626(0x7b538a1840EAf2Ed92EEB67eE744AE627335e201);
+        // Donor of EURC tokens
+        erc4626State.underlyingDonor = 0xBF14DB80D9275FB721383a77C00Ae180fc40ae98;
+        erc4626State.amountToDonate = 1e5 * 1e6;
+    }
+}


### PR DESCRIPTION
waCoreEURC (Wrapped Aave Core) on Avalanche, available at https://app.aave.com
Contract: https://snowtrace.io/token/0x7b538a1840eaf2ed92eeb67ee744ae627335e201

All tests pass